### PR TITLE
NEW Add configurability for which authenticator selection criteria to use in registration, default to cross platform

### DIFF
--- a/docs/en/readme.md
+++ b/docs/en/readme.md
@@ -1,7 +1,41 @@
-# Documentation
-Add your documentation in the docs/en folder as markdown. Note the "en" refers to the langugae used in the documentation you provide.
-If you documentation is vast, you can split it into many markdown files and sub folders.
+# Developer documentation
 
-Look over the [guidance on documentation](https://docs.silverstripe.org/en/contributing/documentation/) 
+## What is WebAuthn
 
-Make sure to remove this readme in your actual module!
+We use the web-auth/webauthn-framework PHP library to provide support for the Web Authentication protocol:
+
+> Webauthn defines an API enabling the creation and use of strong, attested, scoped, public key-based credentials by
+> web applications, for the purpose of strongly authenticating users.
+
+See https://github.com/web-auth/webauthn-framework for more information on the underlying PHP library.
+
+## Configuration
+
+### "Find out more" links
+
+You can configure (or remove) the "Find out more" links shown to users when the "Security key" authentication method
+option is shown in multi-factor authentication registration or verification flows by adjusting the user help link
+in configuration:
+
+```yaml
+SilverStripe\WebAuthn\RegisterHandler:
+  user_help_link: 'http://intranet.mycompany.com/help/how-to-use-mfa'
+```
+
+### Authenticator Selection Criteria
+
+The way the `Webauthn\AuthenticatorSelectionCriteria` instance is configured will define how appropriate authenticators
+are selected to participate in the creation operation of WebAuthn attestations. It has three settings, which are
+explained in [the MDN web docs for authenticatorSelection](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions/authenticatorSelection#Syntax).
+
+The SilverStripe WebAuthn module allows you to configure the `authenticatorAttachment` option, which is responsible
+for determining whether single or cross-platform authenticators can be used in the registration operation. The default
+is that devices must be cross-platform (e.g. security keys) while single-platform devices (e.g. touch ID on mobile
+phones) are disabled. You can adjust this setting by configuring
+`SilverStripe\WebAuthn\RegisterHandler.authenticator_attachment` to use one of these options:
+
+* `AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_NO_PREFERENCE`: allows either
+* `AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_PLATFORM`: single-platform only
+* `AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM `: cross-platform only
+
+For more information, see [Authenticator Selection Criteria](https://github.com/web-auth/webauthn-framework/blob/v1.2/doc/webauthn/PublicKeyCredentialCreation.md#authenticator-selection-criteria)

--- a/src/RegisterHandler.php
+++ b/src/RegisterHandler.php
@@ -47,6 +47,16 @@ class RegisterHandler implements RegisterHandlerInterface
     private static $user_help_link;
 
     /**
+     * The default attachment mode to use for Authentication Selection Criteria.
+     *
+     * See {@link getAuthenticatorSelectionCriteria()} for more information.
+     *
+     * @config
+     * @var string
+     */
+    private static $authenticator_attachment = AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM;
+
+    /**
      * Stores any data required to handle a registration process with a method, and returns relevant state to be applied
      * to the front-end application managing the process.
      *
@@ -215,7 +225,7 @@ class RegisterHandler implements RegisterHandlerInterface
             [new PublicKeyCredentialParameters('public-key', PublicKeyCredentialParameters::ALGORITHM_ES256)],
             40000,
             [],
-            new AuthenticatorSelectionCriteria(),
+            $this->getAuthenticatorSelectionCriteria(),
             PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
             new AuthenticationExtensionsClientInputs()
         );
@@ -223,5 +233,23 @@ class RegisterHandler implements RegisterHandlerInterface
         $store->setState(['credentialOptions' => $credentialOptions] + $state);
 
         return $credentialOptions;
+    }
+
+    /**
+     * Returns an "Authenticator Selection Criteria" object which is intended to select the appropriate authenticators
+     * to participate in the creation operation.
+     *
+     * The default is to allow only "cross platform" authenticators, e.g. disabling "single platform" authenticators
+     * such as touch ID.
+     *
+     * For more information: https://github.com/web-auth/webauthn-framework/blob/v1.2/doc/webauthn/PublicKeyCredentialCreation.md#authenticator-selection-criteria
+     *
+     * @return AuthenticatorSelectionCriteria
+     */
+    protected function getAuthenticatorSelectionCriteria(): AuthenticatorSelectionCriteria
+    {
+        return new AuthenticatorSelectionCriteria(
+            (string) $this->config()->get('authenticator_attachment')
+        );
     }
 }

--- a/src/RegisterHandler.php
+++ b/src/RegisterHandler.php
@@ -5,6 +5,7 @@ namespace SilverStripe\WebAuthn;
 use CBOR\Decoder;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\Tag\TagObjectManager;
+use Cose\Algorithms;
 use Exception;
 use GuzzleHttp\Psr7\ServerRequest;
 use SilverStripe\Control\Director;
@@ -180,6 +181,9 @@ class RegisterHandler implements RegisterHandlerInterface
         return 'WebAuthnRegister';
     }
 
+    /**
+     * @return PublicKeyCredentialRpEntity
+     */
     protected function getRelyingPartyEntity(): PublicKeyCredentialRpEntity
     {
         // Relying party entity ONLY allows domains or subdomains. Remove ports or anything else that isn't already.
@@ -193,6 +197,10 @@ class RegisterHandler implements RegisterHandlerInterface
         );
     }
 
+    /**
+     * @param Member $member
+     * @return PublicKeyCredentialUserEntity
+     */
     protected function getUserEntity(Member $member): PublicKeyCredentialUserEntity
     {
         return new PublicKeyCredentialUserEntity(
@@ -222,7 +230,7 @@ class RegisterHandler implements RegisterHandlerInterface
             $this->getRelyingPartyEntity(),
             $this->getUserEntity($store->getMember()),
             random_bytes(32),
-            [new PublicKeyCredentialParameters('public-key', PublicKeyCredentialParameters::ALGORITHM_ES256)],
+            [new PublicKeyCredentialParameters('public-key', Algorithms::COSE_ALGORITHM_ES256)],
             40000,
             [],
             $this->getAuthenticatorSelectionCriteria(),


### PR DESCRIPTION
This applies to WebAuthn _registration_, where verification uses the saved attestation information from the registration process.

Fixes https://github.com/silverstripe/silverstripe-webauthn-authenticator/issues/17

Docs:

* https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions/authenticatorSelection
* https://github.com/web-auth/webauthn-framework/blob/v1.2/doc/webauthn/PublicKeyCredentialCreation.md#authenticator-selection-criteria