### PR TITLE
FIX don't kill execution when errors are detected

### DIFF
--- a/src/CredentialRepository.php
+++ b/src/CredentialRepository.php
@@ -11,7 +11,7 @@ use Webauthn\CredentialRepository as CredentialRepositoryInterface;
 
 /**
  * This interface is required by the WebAuthn library but is too exhaustive for our "one security key per person"
- * registration. We only support one and it's stored on the registered method that's a dependency of the constructor
+ * registration. We only support one and it's stored on the RegisteredMethod that is a dependency of the constructor
  */
 class CredentialRepository implements CredentialRepositoryInterface
 {

--- a/src/ResponseDataException.php
+++ b/src/ResponseDataException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\WebAuthn;
+
+use RuntimeException;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorData;
+
+/**
+ * Exception to be thrown when a {@see AuthenticatorAttestationResponse} is expected to contain attested credential
+ * data but does not. {@see AuthenticatorData::hasAttestedCredentialData}
+ */
+class ResponseDataException extends RuntimeException
+{
+}

--- a/src/ResponseTypeExecption.php
+++ b/src/ResponseTypeExecption.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\WebAuthn;
+
+use RuntimeException;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\PublicKeyCredentialLoader;
+
+/**
+ * Represents an error found when the AuthenticatorResponse from a challenge is not of the expected type
+ * e.g. for verification we expect {@see AuthenticatorAssertionResponse}
+ * but could instead be returned a {@see AuthenticatorAttestationResponse}
+ * It is an extreme edge case, but is technically possible
+ * {@see PublicKeyCredentialLoader::createResponse}
+ */
+class ResponseTypeException extends RuntimeException
+{
+}


### PR DESCRIPTION
Instead we should log the error, then re-throw them. This will be useful for debugging purposes, while maintaining existing functionality (while also keeping things functional).