### PR TITLE
API Implemented the non-deprecated interface for credential repository

### DIFF
--- a/src/CredentialRepository.php
+++ b/src/CredentialRepository.php
@@ -106,7 +106,7 @@ class CredentialRepository implements PublicKeyCredentialSourceRepository, Seria
             return [];
         }
 
-        return array_map(function($credentialComposite) {
+        return array_map(function ($credentialComposite) {
             return $credentialComposite['source'];
         }, $this->credentials);
     }
@@ -123,6 +123,14 @@ class CredentialRepository implements PublicKeyCredentialSourceRepository, Seria
 
         $this->credentials[$ref]['source'] = $publicKeyCredentialSource;
         $this->hasChanged = true;
+    }
+
+    /**
+     * Empty the store deleting all stored credentials
+     */
+    public function reset(): void
+    {
+        $this->credentials = [];
     }
 
     /**
@@ -185,26 +193,11 @@ class CredentialRepository implements PublicKeyCredentialSourceRepository, Seria
         return $new;
     }
 
-    /**
-     * String representation of object
-     * @link https://php.net/manual/en/serializable.serialize.php
-     * @return string the string representation of the object or null
-     * @since 5.1.0
-     */
     public function serialize()
     {
         return json_encode(['credentials' => $this->toArray(), 'memberID' => $this->memberID]);
     }
 
-    /**
-     * Constructs the object
-     * @link https://php.net/manual/en/serializable.unserialize.php
-     * @param string $serialized <p>
-     * The string representation of the object.
-     * </p>
-     * @return void
-     * @since 5.1.0
-     */
     public function unserialize($serialized)
     {
         $raw = json_decode($serialized, true);

--- a/src/CredentialRepository.php
+++ b/src/CredentialRepository.php
@@ -45,6 +45,8 @@ class CredentialRepository implements PublicKeyCredentialSourceRepository, Seria
 
     public function get(string $credentialId): AttestedCredentialData
     {
+        $this->assertCredentialID($credentialId);
+
         return $this->findOneByCredentialId($credentialId)->getAttestedCredentialData();
     }
 

--- a/src/CredentialRepository.php
+++ b/src/CredentialRepository.php
@@ -3,99 +3,192 @@
 namespace SilverStripe\WebAuthn;
 
 use InvalidArgumentException;
-use SilverStripe\MFA\Model\RegisteredMethod;
-use SilverStripe\Security\Member;
-use TypeError;
+use Serializable;
 use Webauthn\AttestedCredentialData;
-use Webauthn\CredentialRepository as CredentialRepositoryInterface;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\PublicKeyCredentialSourceRepository;
+use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
  * This interface is required by the WebAuthn library but is too exhaustive for our "one security key per person"
  * registration. We only support one and it's stored on the RegisteredMethod that is a dependency of the constructor
  */
-class CredentialRepository implements CredentialRepositoryInterface
+class CredentialRepository implements PublicKeyCredentialSourceRepository, Serializable
 {
     /**
-     * @var RegisteredMethod
+     * @var string
      */
-    protected $registeredMethod;
+    private $memberID;
 
     /**
-     * @var Member
+     * @var array
      */
-    protected $member;
+    private $credentials = [];
 
     /**
-     * CredentialRepository constructor.
-     * @param Member $member
-     * @param RegisteredMethod $registeredMethod
+     * @var bool
      */
-    public function __construct(Member $member, RegisteredMethod $registeredMethod = null)
+    private $hasChanged = false;
+
+    /**
+     * @param string $memberID
+     */
+    public function __construct(string $memberID)
     {
-        $this->member = $member;
-        $this->registeredMethod = $registeredMethod;
+        $this->memberID = $memberID;
     }
 
     public function has(string $credentialId): bool
     {
-        $data = $this->getCredentialData()['data'] ?? [];
-
-        return isset($data['credentialId']) && $data['credentialId'] === base64_encode($credentialId);
+        return $this->findOneByCredentialId($credentialId) !== null;
     }
 
     public function get(string $credentialId): AttestedCredentialData
     {
-        $this->assertCredentialID($credentialId);
-
-        $data = $this->getCredentialData();
-
-        return AttestedCredentialData::createFromArray($data['data']);
+        return $this->findOneByCredentialId($credentialId)->getAttestedCredentialData();
     }
 
     public function getUserHandleFor(string $credentialId): string
     {
         $this->assertCredentialID($credentialId);
 
-        return (string) $this->member->ID;
+        return $this->memberID;
     }
 
     public function getCounterFor(string $credentialId): int
     {
         $this->assertCredentialID($credentialId);
 
-        return (int) $this->getCredentialData()['counter'];
+        return (int) $this->credentials[$this->getCredentialIDRef($credentialId)]['counter'];
     }
 
     public function updateCounterFor(string $credentialId, int $newCounter): void
     {
         $this->assertCredentialID($credentialId);
 
-        $this->registeredMethod->Data = json_encode([
-            'counter' => $newCounter,
-        ] + $this->getCredentialData());
-        $this->registeredMethod->write();
-    }
-
-    protected function getCredentialData(): array
-    {
-        if (!$this->registeredMethod) {
-            return [];
-        }
-
-        try {
-            return json_decode($this->registeredMethod->Data, true);
-        } catch (TypeError $error) {
-            return [];
-        }
+        $this->credentials[$this->getCredentialIDRef($credentialId)]['counter'] = $newCounter;
+        $this->hasChanged = true;
     }
 
     /**
+     * Assert that the given credential ID matches a stored credential
+     *
      * @param string $credentialId
      */
     protected function assertCredentialID(string $credentialId): void
     {
         if (!$this->has($credentialId)) {
-            throw new InvalidArgumentException('Given credential ID does not match any database record');
+            throw new InvalidArgumentException('Given credential ID does not match any stored credentials');
         }
+    }
+
+    public function findOneByCredentialId(string $publicKeyCredentialId): ?PublicKeyCredentialSource
+    {
+        $ref = $this->getCredentialIDRef($publicKeyCredentialId);
+        if (!isset($this->credentials[$ref])) {
+            return null;
+        }
+
+        return $this->credentials[$ref]['source'];
+    }
+
+    /**
+     * @return PublicKeyCredentialSource[]
+     */
+    public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array
+    {
+        // Only return credentials if the user entity shares the same ID.
+        if ($publicKeyCredentialUserEntity->getId() !== $this->memberID) {
+            return [];
+        }
+
+        return array_map(function($credentialComposite) {
+            return $credentialComposite['source'];
+        }, $this->credentials);
+    }
+
+    public function saveCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource): void
+    {
+        $ref = $this->getCredentialIDRef($publicKeyCredentialSource->getPublicKeyCredentialId());
+
+        if (!isset($this->credentials[$ref])) {
+            $this->credentials[$ref] = [
+                'counter' => 0,
+            ];
+        }
+
+        $this->credentials[$ref]['source'] = $publicKeyCredentialSource;
+        $this->hasChanged = true;
+    }
+
+    public function hasChanged(): bool
+    {
+        return $this->hasChanged;
+    }
+
+    protected function setCredentials(array $credentials): void
+    {
+        $this->credentials = array_map(function ($data) {
+            $data['source'] = PublicKeyCredentialSource::createFromArray($data['source']);
+            return $data;
+        }, $credentials);
+    }
+
+    protected function getCredentialIDRef(string $credentialID): string
+    {
+        return base64_encode($credentialID);
+    }
+
+    /**
+     * Provide the credentials stored in this repository as an array
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return $this->credentials;
+    }
+
+    /**
+     * Create an instance of a repository from the given credentials
+     *
+     * @param array $credentials
+     * @param string $memberID
+     * @return CredentialRepository
+     */
+    public static function fromArray(array $credentials, string $memberID)
+    {
+        $new = new static($memberID);
+        $new->setCredentials($credentials);
+
+        return $new;
+    }
+
+    /**
+     * String representation of object
+     * @link https://php.net/manual/en/serializable.serialize.php
+     * @return string the string representation of the object or null
+     * @since 5.1.0
+     */
+    public function serialize()
+    {
+        return json_encode(['credentials' => $this->toArray(), 'memberID' => $this->memberID]);
+    }
+
+    /**
+     * Constructs the object
+     * @link https://php.net/manual/en/serializable.unserialize.php
+     * @param string $serialized <p>
+     * The string representation of the object.
+     * </p>
+     * @return void
+     * @since 5.1.0
+     */
+    public function unserialize($serialized)
+    {
+        $raw = json_decode($serialized, true);
+
+        $this->memberID = $raw['memberID'];
+        $this->setCredentials($raw['credentials']);
     }
 }

--- a/src/CredentialRepositoryProviderTrait.php
+++ b/src/CredentialRepositoryProviderTrait.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\WebAuthn;
+
+use SilverStripe\MFA\Service\RegisteredMethodManager;
+use SilverStripe\MFA\Store\StoreInterface;
+use SilverStripe\Security\Member;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+trait CredentialRepositoryProviderTrait
+{
+    /**
+     * @param StoreInterface $store
+     * @return CredentialRepository
+     */
+    protected function getCredentialRepository(StoreInterface $store): CredentialRepository
+    {
+        $state = $store->getState();
+
+        // Check state from the store (session)
+        if (isset($state['repository']) && $state['repository'] instanceof CredentialRepository) {
+            return $state['repository'];
+        }
+
+        // Check if the member has an existing webauthn registered method to add to
+        $member = $store->getMember();
+        $method = RegisteredMethodManager::singleton()->getFromMember(
+            $member,
+            new Method()
+        );
+
+        if ($method) {
+            // Unserialize is used here but it the class implements `Serializable` to serialise as JSON.
+            $credentialRepository = CredentialRepository::fromArray(
+                json_decode($method->Data, true),
+                (string) $store->getMember()->ID
+            );
+        } else {
+            $credentialRepository = new CredentialRepository((string)$member->ID);
+        }
+
+        // Persist the credential repository in the store
+        $store->addState(['repository' => $credentialRepository]);
+
+        return $credentialRepository;
+    }
+
+    /**
+     * @param Member $member
+     * @return PublicKeyCredentialUserEntity
+     */
+    protected function getUserEntity(Member $member): PublicKeyCredentialUserEntity
+    {
+        return new PublicKeyCredentialUserEntity(
+            $member->getName(),
+            (string) $member->ID,
+            $member->getName()
+        );
+    }
+}

--- a/src/CredentialRepositoryProviderTrait.php
+++ b/src/CredentialRepositoryProviderTrait.php
@@ -36,13 +36,12 @@ trait CredentialRepositoryProviderTrait
         }
 
         if ($registeredMethod) {
-            // Unserialize is used here but it the class implements `Serializable` to serialise as JSON.
             $credentialRepository = CredentialRepository::fromArray(
                 (array) json_decode($registeredMethod->Data, true),
-                (string) $store->getMember()->ID
+                (string) $member->ID
             );
         } else {
-            $credentialRepository = new CredentialRepository((string)$member->ID);
+            $credentialRepository = new CredentialRepository((string) $member->ID);
         }
 
         // Persist the credential repository in the store

--- a/src/RegisterHandler.php
+++ b/src/RegisterHandler.php
@@ -150,6 +150,11 @@ class RegisterHandler implements RegisterHandlerInterface
             $options->getUser()->getId()
         );
 
+        // Clear the repository so only one key is registered at a time
+        // NOTE: This can be considered temporary behaviour until the UI supports managing multiple keys
+        $credentialRepository->reset();
+
+        // Persist the "credential source"
         $credentialRepository->saveCredentialSource($source);
 
         return Result::create()->setContext($credentialRepository->toArray());
@@ -196,7 +201,7 @@ class RegisterHandler implements RegisterHandlerInterface
      */
     public function getSupportLink(): string
     {
-        return static::config()->get('user_help_link') ?: '';
+        return $this->config()->get('user_help_link') ?: '';
     }
 
     /**

--- a/src/VerifyHandler.php
+++ b/src/VerifyHandler.php
@@ -129,9 +129,10 @@ class VerifyHandler implements VerifyHandlerInterface
 
     /**
      * @param StoreInterface $store
-     * @param RegisteredMethod $registeredMethod
+     * @param RegisteredMethod|null $registeredMethod
      * @param bool $reset
      * @return PublicKeyCredentialRequestOptions
+     * @throws AuthenticationFailedException
      * @throws Exception
      */
     protected function getCredentialRequestOptions(
@@ -153,7 +154,7 @@ class VerifyHandler implements VerifyHandlerInterface
             throw new AuthenticationFailedException('User does not appear to have any credentials loaded for webauthn');
         }
 
-        $descriptors = array_map(function(PublicKeyCredentialSource $source) {
+        $descriptors = array_map(function (PublicKeyCredentialSource $source) {
             return $source->getPublicKeyCredentialDescriptor();
         }, $validCredentials);
 

--- a/tests/CredentialRepositoryTest.php
+++ b/tests/CredentialRepositoryTest.php
@@ -61,6 +61,7 @@ class CredentialRepositoryTest extends SapphireTest
         $creds = [];
 
         foreach ($names as $id) {
+            // phpcs:disable
             $creds[base64_encode($id)] = [
                 'source' => [
                     'publicKeyCredentialId' => $id,
@@ -68,18 +69,19 @@ class CredentialRepositoryTest extends SapphireTest
                     'transports' =>
                         array (
                         ),
-                    'attestationType' => 'none',
-                    'trustPath' =>
+                        'attestationType' => 'none',
+                        'trustPath' =>
                         array (
                             'type' => 'empty',
                         ),
-                    'aaguid' => 'AAAAAAAAAAAAAAAAAAAAAA',
-                    'credentialPublicKey' => 'pQECAyYgASFYII3gDdvOBje5JfjNO0VhxE2RrV5XoKqWmCZAmR0f9nFaIlggZOUvkovGH9cfeyfXEpJAVOzR1d-rVRZJvwWJf444aLo',
-                    'userHandle' => 'MQ',
-                    'counter' => 268,
+                        'aaguid' => 'AAAAAAAAAAAAAAAAAAAAAA',
+                        'credentialPublicKey' => 'pQECAyYgASFYII3gDdvOBje5JfjNO0VhxE2RrV5XoKqWmCZAmR0f9nFaIlggZOUvkovGH9cfeyfXEpJAVOzR1d-rVRZJvwWJf444aLo',
+                        'userHandle' => 'MQ',
+                        'counter' => 268,
                 ],
                 'counter' => $counterValue,
             ];
+            // phpcs:enable
         }
 
         return $creds;

--- a/tests/RegisterHandlerTest.php
+++ b/tests/RegisterHandlerTest.php
@@ -213,6 +213,7 @@ class RegisterHandlerTest extends SapphireTest
      */
     public function registerProvider()
     {
+        // phpcs:disable
         $testSource = PublicKeyCredentialSource::createFromArray([
             'publicKeyCredentialId' => 'g8e1UH4B1gUYl_7AiDXHTp8SE3cxYnpC6jF3Fo0KMm79FNN_e34hDE1Mnd4FSOoNW6B-p7xB2tqj28svkJQh1Q',
             'type' => 'public-key',
@@ -226,6 +227,7 @@ class RegisterHandlerTest extends SapphireTest
             'userHandle' => 'MQ',
             'counter' => 268,
         ]);
+        // phpcs:enable
 
         $authDataMock = $this->createMock(AuthenticatorData::class);
         $authDataMock->expects($this->exactly(3))->method('hasAttestedCredentialData')

--- a/tests/VerifyHandlerTest.php
+++ b/tests/VerifyHandlerTest.php
@@ -68,6 +68,8 @@ class VerifyHandlerTest extends SapphireTest
         $this->store = new SessionStore($this->member);
 
         $this->registeredMethod = new RegisteredMethod();
+
+        // phpcs:disable
         $this->registeredMethod->Data = json_encode([
             'g8e1UH4B1gUYl\/7AiDXHTp8SE3cxYnpC6jF3Fo0KMm79FNN\/e34hDE1Mnd4FSOoNW6B+p7xB2tqj28svkJQh1Q==' => [
                 'source' => [
@@ -89,6 +91,7 @@ class VerifyHandlerTest extends SapphireTest
                 'counter' => 0,
             ]
         ]);
+        // phpcs:enable
     }
 
     /**

--- a/tests/VerifyHandlerTest.php
+++ b/tests/VerifyHandlerTest.php
@@ -69,25 +69,34 @@ class VerifyHandlerTest extends SapphireTest
 
         $this->registeredMethod = new RegisteredMethod();
         $this->registeredMethod->Data = json_encode([
-            'descriptor' => [
-                'type' => 'public-key',
-                'id' => '7lE6zdHESCF3/qSijHVuTwlTNi/yZSD/XP6Nm6HBI8YLA0uzPqyU4U4RxyZyuKXEPiIENEr509TekP2mDKrFoQ=='
-            ],
-            'data' => [
-                'aaguid' => 'AAAAAAAAAAAAAAAAAAAAAA==',
-                'credentialId' => '7lE6zdHESCF3/qSijHVuTwlTNi/yZSD/XP6Nm6HBI8YLPiIENEr509TekP2mDKrFoQ==',
-                'credentialPublicKey' => 'pU4vyn6OmHbdDyx7nWsJD+/2CycZkGzJ1u3TVj+c='
-            ],
-            'counter' => null,
+            'g8e1UH4B1gUYl\/7AiDXHTp8SE3cxYnpC6jF3Fo0KMm79FNN\/e34hDE1Mnd4FSOoNW6B+p7xB2tqj28svkJQh1Q==' => [
+                'source' => [
+                    'publicKeyCredentialId' => 'g8e1UH4B1gUYl_7AiDXHTp8SE3cxYnpC6jF3Fo0KMm79FNN_e34hDE1Mnd4FSOoNW6B-p7xB2tqj28svkJQh1Q',
+                    'type' => 'public-key',
+                    'transports' =>
+                        array (
+                        ),
+                    'attestationType' => 'none',
+                    'trustPath' =>
+                        array (
+                            'type' => 'empty',
+                        ),
+                    'aaguid' => 'AAAAAAAAAAAAAAAAAAAAAA',
+                    'credentialPublicKey' => 'pQECAyYgASFYII3gDdvOBje5JfjNO0VhxE2RrV5XoKqWmCZAmR0f9nFaIlggZOUvkovGH9cfeyfXEpJAVOzR1d-rVRZJvwWJf444aLo',
+                    'userHandle' => 'MQ',
+                    'counter' => 268,
+                ],
+                'counter' => 0,
+            ]
         ]);
     }
 
     /**
-     * @expectedException \Assert\InvalidArgumentException
+     * @expectedException \SilverStripe\MFA\Exception\AuthenticationFailedException
      */
     public function testStartThrowsExceptionWithMissingData()
     {
-        $this->registeredMethod->Data = null;
+        $this->registeredMethod->Data = '';
         $this->handler->start($this->store, $this->registeredMethod);
     }
 


### PR DESCRIPTION
This module now supports multiple registration for WebAuthn although it is not possible through the UI. The repository itself is stored against the registered method.

Resolves #11