### PR TITLE
NEW Add links to userhelp documentation

### DIFF
--- a/src/RegisterHandler.php
+++ b/src/RegisterHandler.php
@@ -35,12 +35,11 @@ class RegisterHandler implements RegisterHandlerInterface
 
     /**
      * Provide a user help link that will be available when registering backup codes
-     * TODO Will this have a user help link as a default?
      *
      * @config
      * @var string
      */
-    private static $user_help_link;
+    private static $user_help_link = 'https://userhelp.silverstripe.org/en/4/optional_features/multi-factor_authentication/user_manual/using_security_keys/'; // phpcs-disable-line
 
     /**
      * The default attachment mode to use for Authentication Selection Criteria.


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-mfa/issues/239. Requires https://github.com/silverstripe/silverstripe-userhelp-content/pull/137.