### PR TITLE
DEP Use guzzlehttp/psr7 ^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "ext-bcmath": "*",
         "silverstripe/mfa": "^4.0",
         "web-auth/webauthn-lib": "^3.3",
-        "guzzlehttp/psr7": "^1.6"
+        "guzzlehttp/psr7": "^2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10253

Only references to guzzle psr7 in the module is calling `SererRequest::fromGlobals()` which is unchanged between guzzle psr7 v1 and v2

https://github.com/guzzle/psr7/blob/1.x/src/ServerRequest.php#L170
https://github.com/guzzle/psr7/blob/master/src/ServerRequest.php#L166

Have manually confirmed locally that yubikey registration and authentication still works with guzzlehttp/psr7 ^2