### PR TITLE
FIX Handle when state holds an object instead of array

### DIFF
--- a/src/RegisterHandler.php
+++ b/src/RegisterHandler.php
@@ -248,7 +248,10 @@ class RegisterHandler implements RegisterHandlerInterface
         $state = $store->getState();
 
         if (!$reset && !empty($state) && !empty($state['credentialOptions'])) {
-            return PublicKeyCredentialCreationOptions::createFromArray($state['credentialOptions']);
+            if (is_array($state['credentialOptions'])) {
+                return PublicKeyCredentialCreationOptions::createFromArray($state['credentialOptions']);
+            }
+            return $state['credentialOptions'];
         }
 
         $credentialOptions = new PublicKeyCredentialCreationOptions(


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-webauthn-authenticator/issues/110

Have tested locally and on a production like environment