### PR TITLE
FIX Handle updated serialize methods in silverstripe/mfa

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-bcmath": "*",
-        "silverstripe/mfa": "^4.0",
+        "silverstripe/mfa": "^4.6",
         "web-auth/webauthn-lib": "^3.3",
         "guzzlehttp/psr7": "^2"
     },

--- a/src/CredentialRepository.php
+++ b/src/CredentialRepository.php
@@ -154,7 +154,9 @@ class CredentialRepository implements PublicKeyCredentialSourceRepository, Seria
     protected function setCredentials(array $credentials): void
     {
         $this->credentials = array_map(function ($data) {
-            $data['source'] = PublicKeyCredentialSource::createFromArray($data['source']);
+            if (is_array($data['source'])) {
+                $data['source'] = PublicKeyCredentialSource::createFromArray($data['source']);
+            }
             return $data;
         }, $credentials ?? []);
     }

--- a/src/RegisterHandler.php
+++ b/src/RegisterHandler.php
@@ -247,8 +247,12 @@ class RegisterHandler implements RegisterHandlerInterface
     ): PublicKeyCredentialCreationOptions {
         $state = $store->getState();
 
-        if (!$reset && !empty($state) && !empty($state['credentialOptions'])) {
-            return PublicKeyCredentialCreationOptions::createFromArray($state['credentialOptions']);
+        if (
+            !$reset &&
+            isset($state['credentialOptions']) &&
+            $state['credentialOptions'] instanceof PublicKeyCredentialCreationOptions
+        ) {
+            return $state['credentialOptions'];
         }
 
         $credentialOptions = new PublicKeyCredentialCreationOptions(

--- a/src/VerifyHandler.php
+++ b/src/VerifyHandler.php
@@ -146,8 +146,12 @@ class VerifyHandler implements VerifyHandlerInterface
     ): PublicKeyCredentialRequestOptions {
         $state = $store->getState();
 
-        if (!$reset && !empty($state) && !empty($state['credentialOptions'])) {
-            return PublicKeyCredentialRequestOptions::createFromArray($state['credentialOptions']);
+        if (
+            !$reset &&
+            isset($state['credentialOptions']) &&
+            $state['credentialOptions'] instanceof PublicKeyCredentialRequestOptions
+        ) {
+            return $state['credentialOptions'];
         }
 
         // Use the interface methods (despite the fact the "repository" is per-member in this module)


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-webauthn-authenticator/issues/110

https://github.com/silverstripe/silverstripe-mfa/commit/eb8d813f0dc77682293ba5d99c181b7d3cbf902c added new __serlialize/__unserialize methods for PHP 8.1 compatibility.  They better handle the whole serialization process, though it also means the actually PHP objects are hydrated rather than just json data.