### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-bcmath": "*",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/mfa": "4.8.x-dev",
+        "silverstripe/framework": "^4.12",
+        "silverstripe/mfa": "^4.6",
         "web-auth/webauthn-lib": "^3.3",
         "guzzlehttp/psr7": "^2"
     },


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33