### PR TITLE
FIX Pass AuthenticatorSelectionCriteria as argument to PublicKeyCredentialCreationOptions constructor

### DIFF
--- a/src/RegisterHandler.php
+++ b/src/RegisterHandler.php
@@ -261,6 +261,7 @@ class RegisterHandler implements RegisterHandlerInterface
             [new PublicKeyCredentialParameters('public-key', Algorithms::COSE_ALGORITHM_ES256)],
             $this->getAuthenticatorSelectionCriteria()
         );
+        $credentialOptions->setTimeout(40000);
         $credentialOptions->setAuthenticatorSelection($this->getAuthenticatorSelectionCriteria());
         $credentialOptions->setAttestation(PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE);
 
@@ -282,6 +283,7 @@ class RegisterHandler implements RegisterHandlerInterface
      */
     protected function getAuthenticatorSelectionCriteria(): AuthenticatorSelectionCriteria
     {
-        return AuthenticatorSelectionCriteria::create((string) $this->config()->get('authenticator_attachment'));
+        return AuthenticatorSelectionCriteria::create()
+            ->setAuthenticatorAttachment((string) $this->config()->get('authenticator_attachment'));
     }
 }

--- a/src/RegisterHandler.php
+++ b/src/RegisterHandler.php
@@ -259,7 +259,7 @@ class RegisterHandler implements RegisterHandlerInterface
             $this->getUserEntity($store->getMember()),
             random_bytes(32),
             [new PublicKeyCredentialParameters('public-key', Algorithms::COSE_ALGORITHM_ES256)],
-            40000
+            $this->getAuthenticatorSelectionCriteria()
         );
         $credentialOptions->setAuthenticatorSelection($this->getAuthenticatorSelectionCriteria());
         $credentialOptions->setAttestation(PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE);
@@ -282,7 +282,6 @@ class RegisterHandler implements RegisterHandlerInterface
      */
     protected function getAuthenticatorSelectionCriteria(): AuthenticatorSelectionCriteria
     {
-        return AuthenticatorSelectionCriteria::create()
-            ->setAuthenticatorAttachment((string) $this->config()->get('authenticator_attachment'));
+        return AuthenticatorSelectionCriteria::create((string) $this->config()->get('authenticator_attachment'));
     }
 }

--- a/src/VerifyHandler.php
+++ b/src/VerifyHandler.php
@@ -185,7 +185,8 @@ class VerifyHandler implements VerifyHandlerInterface
             return $source->getPublicKeyCredentialDescriptor();
         }, $validCredentials ?? []);
 
-        $options = new PublicKeyCredentialRequestOptions(random_bytes(32), 40000);
+        $options = new PublicKeyCredentialRequestOptions((string) random_bytes(32));
+        $options->setTimeout(40000);
 
         $options->allowCredentials(...$descriptors);
         $options->setUserVerification(PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_PREFERRED);


### PR DESCRIPTION
## Description
- [Webauthn/PublicKeyCredentialCreationOptions](https://github.com/web-auth/webauthn-lib/blob/4.7.x/src/PublicKeyCredentialCreationOptions.php) requires AuthenticatorSelectionCriteria type as authenticatorSelection argument;
- In "web-auth/webauthn-lib" version 3.3, which we used in CMS 4.13, the second parameter is timeout. See https://github.com/web-auth/webauthn-lib/blob/v3.3/src/PublicKeyCredentialRequestOptions.php
In version 4.4, which we use in CMS 5, it accepts only one parameter at all. We invoke parent constructor. See https://github.com/web-auth/webauthn-lib/blob/4.4.x/src/PublicKeyCredentialRequestOptions.php
In version 4.7, the timeout is taken as parameter 5 in constructor.  See https://github.com/web-auth/webauthn-lib/blob/4.7.x/src/PublicKeyCredentialRequestOptions.php

## Parent issue
- https://github.com/silverstripe/.github/issues/114