### PR TITLE
FIX Expose localisations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "extra": {
         "expose": [
-            "client/dist"
+            "client/dist",
+            "client/lang"
         ]
     },
     "minimum-stability": "dev",

--- a/src/Method.php
+++ b/src/Method.php
@@ -74,6 +74,7 @@ class Method implements MethodInterface
      */
     public function applyRequirements(): void
     {
+        Requirements::add_i18n_javascript('silverstripe/webauthn-authenticator: client/lang');
         Requirements::javascript('silverstripe/webauthn-authenticator: client/dist/js/bundle.js');
         Requirements::css('silverstripe/webauthn-authenticator: client/dist/styles/bundle.css');
     }

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -42,7 +42,7 @@ class MethodTest extends SapphireTest
         $method = new Method();
         $method->applyRequirements();
 
-        $this->assertCount(1, Requirements::backend()->getJavascript());
+        $this->assertcount(2, Requirements::backend()->getJavascript());
         $this->assertCount(1, Requirements::backend()->getCSS());
     }
 


### PR DESCRIPTION
Localisation files weren't exposed via composer vendor-expose, and also weren't being required via the requirements API. Because of this, only the default (English) strings were ever used.

## Issue
- https://github.com/silverstripe/silverstripe-totp-authenticator/issues/138