### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-bcmath": "*",
-        "silverstripe/framework": "^4.12",
+        "silverstripe/framework": "^4.13",
         "silverstripe/mfa": "^4.6",
         "web-auth/webauthn-lib": "^3.3",
         "guzzlehttp/psr7": "^2"


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Failing on Deprecation::withNoReplacement() on --prefer-lowest build

https://github.com/silverstripe/silverstripe-webauthn-authenticator/actions/runs/9851675364