### PR TITLE
API Explicity mark nullable parameters for PHP 8.4

### DIFF
--- a/src/CredentialRepositoryProviderTrait.php
+++ b/src/CredentialRepositoryProviderTrait.php
@@ -19,7 +19,7 @@ trait CredentialRepositoryProviderTrait
      */
     protected function getCredentialRepository(
         StoreInterface $store,
-        RegisteredMethod $registeredMethod = null
+        ?RegisteredMethod $registeredMethod = null
     ): CredentialRepository {
         $state = $store->getState();
 

--- a/src/VerifyHandler.php
+++ b/src/VerifyHandler.php
@@ -165,7 +165,7 @@ class VerifyHandler implements VerifyHandlerInterface
      */
     protected function getCredentialRequestOptions(
         StoreInterface $store,
-        RegisteredMethod $registeredMethod = null,
+        ?RegisteredMethod $registeredMethod = null,
         $reset = false
     ): PublicKeyCredentialRequestOptions {
         $state = $store->getState();

--- a/tests/RegisterHandlerTest.php
+++ b/tests/RegisterHandlerTest.php
@@ -175,8 +175,8 @@ class RegisterHandlerTest extends SapphireTest
         $mockResponse,
         $expectedResult,
         $expectedCredentialCount,
-        callable $responseValidatorMockCallback = null,
-        callable $storeModifier = null
+        ?callable $responseValidatorMockCallback = null,
+        ?callable $storeModifier = null
     ) {
         /** @var RegisterHandler&MockObject $handlerMock */
         $handlerMock = $this->getMockBuilder(RegisterHandler::class)

--- a/tests/VerifyHandlerTest.php
+++ b/tests/VerifyHandlerTest.php
@@ -129,7 +129,7 @@ class VerifyHandlerTest extends SapphireTest
     public function testVerify(
         $mockResponse,
         $expectedResult,
-        callable $responseValidatorMockCallback = null
+        ?callable $responseValidatorMockCallback = null
     ) {
         /** @var VerifyHandler&MockObject $handlerMock */
         $handlerMock = $this->getMockBuilder(VerifyHandler::class)


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/331

Even though this is not commercially supported for CMS 6, it's still a development dependency so it's better that it does not leave a bunch of deprecation warnings in CI logs